### PR TITLE
Increment galvani

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ click==8.1.3
 requests==2.28.1
 
 # Filetype readers
-galvani @ git+https://github.com/echemdata/galvani.git@1fd9f8454a7054c28464fda6ebb1e4b3c65ad270
+galvani == 0.4.1
 maya==0.6.1
 xlrd==2.0.1
 psutil==5.9.4


### PR DESCRIPTION
Bumps galvani to `0.4.1`: https://github.com/echemdata/galvani/releases/tag/0.4.1